### PR TITLE
Replace validate.js and validator.js with validatejs

### DIFF
--- a/helpers/validate.js
+++ b/helpers/validate.js
@@ -1,4 +1,4 @@
-const Validator = require('validate.js');
+const Validator = require("validatorjs");
 const validator = (body, rules, customMessages, callback) => {
   const validation = new Validator(body, rules, customMessages);
   validation.passes(() => callback(null, true));

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "mongodb": "^4.10.0",
         "node": "^16.18.0",
         "swagger-ui-express": "^4.5.0",
-        "validate.js": "^0.13.1",
-        "validator.js": "^2.0.4"
+        "validatorjs": "^3.22.1"
       },
       "devDependencies": {
         "nodemon": "^2.0.19",
@@ -1363,11 +1362,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/validate.js": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.13.1.tgz",
-      "integrity": "sha512-PnFM3xiZ+kYmLyTiMgTYmU7ZHkjBZz2/+F0DaALc/uUtVzdCt1wAosvYJ5hFQi/hz8O4zb52FQhHZRC+uVkJ+g=="
-    },
     "node_modules/validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
@@ -1376,10 +1370,10 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/validator.js": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/validator.js/-/validator.js-2.0.4.tgz",
-      "integrity": "sha512-6gknFyS1WrkXPlnpcb3hecx2LD4j8dEO+G9/yEJ3RYzUUtV4s3icO/IrAzTZtT9BHRSTNGRtg5JORIt+njMpIw=="
+    "node_modules/validatorjs": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/validatorjs/-/validatorjs-3.22.1.tgz",
+      "integrity": "sha512-451KiCt/3E8qV/8fOUdO0YkA8zUdQBNVxubg9jvgEB+JAg9IlRKrClzwq2ir2ndj7TWmPYQ7bXFb4BxcyX2iWw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -2394,20 +2388,15 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
-    "validate.js": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.13.1.tgz",
-      "integrity": "sha512-PnFM3xiZ+kYmLyTiMgTYmU7ZHkjBZz2/+F0DaALc/uUtVzdCt1wAosvYJ5hFQi/hz8O4zb52FQhHZRC+uVkJ+g=="
-    },
     "validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
       "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
-    "validator.js": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/validator.js/-/validator.js-2.0.4.tgz",
-      "integrity": "sha512-6gknFyS1WrkXPlnpcb3hecx2LD4j8dEO+G9/yEJ3RYzUUtV4s3icO/IrAzTZtT9BHRSTNGRtg5JORIt+njMpIw=="
+    "validatorjs": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/validatorjs/-/validatorjs-3.22.1.tgz",
+      "integrity": "sha512-451KiCt/3E8qV/8fOUdO0YkA8zUdQBNVxubg9jvgEB+JAg9IlRKrClzwq2ir2ndj7TWmPYQ7bXFb4BxcyX2iWw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "mongodb": "^4.10.0",
     "node": "^16.18.0",
     "swagger-ui-express": "^4.5.0",
-    "validate.js": "^0.13.1",
-    "validator.js": "^2.0.4"
+    "validatorjs": "^3.22.1"
   },
   "devDependencies": {
     "nodemon": "^2.0.19",


### PR DESCRIPTION
Alrighty, I think whatever you were using as a guide to get this done uses an npm packaged named `validatejs` rather than `validator.js` or `validate.js`.

In this change, I removed `validator.js` and `validate.js`, then installed `validatejs`. I also changed the "require" statement in the middleware to reflect this change.

After that, everything seems to be working!

References: https://www.npmjs.com/package/validatorjs/v/1.0.0